### PR TITLE
Fix Numbering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docx-h4",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Generate .docx documents with JavaScript (formerly Office-Clippy)",
   "main": "build/index.js",
   "scripts": {

--- a/src/file/numbering/numbering.ts
+++ b/src/file/numbering/numbering.ts
@@ -1,12 +1,13 @@
-import { XmlComponent } from "file/xml-components";
+import { XmlComponent, IXmlableObject } from "file/xml-components";
 import { DocumentAttributes } from "../document/document-attributes";
-import { Indent } from "../paragraph/formatting";
-import { RunFonts } from "../paragraph/run/run-fonts";
 import { AbstractNumbering } from "./abstract-numbering";
 import { Num } from "./num";
 
 export class Numbering extends XmlComponent {
     private nextId: number;
+
+    private abstractNumbering: Array<XmlComponent> = [];
+    private concreteNumbering: Array<XmlComponent> = [];
 
     constructor() {
         super("w:numbering");
@@ -33,66 +34,23 @@ export class Numbering extends XmlComponent {
         );
 
         this.nextId = 0;
-
-        const abstractNumbering = this.createAbstractNumbering();
-
-        abstractNumbering
-            .createLevel(0, "bullet", "•", "left")
-            .addParagraphProperty(new Indent({ left: 720, hanging: 360 }))
-            .addRunProperty(new RunFonts("Symbol", "default"));
-
-        abstractNumbering
-            .createLevel(1, "bullet", "o", "left")
-            .addParagraphProperty(new Indent({ left: 1440, hanging: 360 }))
-            .addRunProperty(new RunFonts("Courier New", "default"));
-
-        abstractNumbering
-            .createLevel(2, "bullet", "•", "left")
-            .addParagraphProperty(new Indent({ left: 2160, hanging: 360 }))
-            .addRunProperty(new RunFonts("Wingdings", "default"));
-
-        abstractNumbering
-            .createLevel(3, "bullet", "•", "left")
-            .addParagraphProperty(new Indent({ left: 2880, hanging: 360 }))
-            .addRunProperty(new RunFonts("Symbol", "default"));
-
-        abstractNumbering
-            .createLevel(4, "bullet", "o", "left")
-            .addParagraphProperty(new Indent({ left: 3600, hanging: 360 }))
-            .addRunProperty(new RunFonts("Courier New", "default"));
-
-        abstractNumbering
-            .createLevel(5, "bullet", "•", "left")
-            .addParagraphProperty(new Indent({ left: 4320, hanging: 360 }))
-            .addRunProperty(new RunFonts("Wingdings", "default"));
-
-        abstractNumbering
-            .createLevel(6, "bullet", "•", "left")
-            .addParagraphProperty(new Indent({ left: 5040, hanging: 360 }))
-            .addRunProperty(new RunFonts("Symbol", "default"));
-
-        abstractNumbering
-            .createLevel(7, "bullet", "o", "left")
-            .addParagraphProperty(new Indent({ left: 5760, hanging: 360 }))
-            .addRunProperty(new RunFonts("Courier New", "default"));
-
-        abstractNumbering
-            .createLevel(8, "bullet", "•", "left")
-            .addParagraphProperty(new Indent({ left: 6480, hanging: 360 }))
-            .addRunProperty(new RunFonts("Wingdings", "default"));
-
-        this.createConcreteNumbering(abstractNumbering);
     }
 
     public createAbstractNumbering(): AbstractNumbering {
         const num = new AbstractNumbering(this.nextId++);
-        this.root.push(num);
+        this.abstractNumbering.push(num);
         return num;
     }
 
     public createConcreteNumbering(abstractNumbering: AbstractNumbering): Num {
         const num = new Num(this.nextId++, abstractNumbering.id);
-        this.root.push(num);
+        this.concreteNumbering.push(num);
         return num;
+    }
+
+    public prepForXml(): IXmlableObject {
+        this.abstractNumbering.forEach(x => this.root.push(x));
+        this.concreteNumbering.forEach(x => this.root.push(x));
+        return super.prepForXml();
     }
 }

--- a/src/file/paragraph/paragraph.ts
+++ b/src/file/paragraph/paragraph.ts
@@ -136,6 +136,11 @@ export class Paragraph extends XmlComponent {
         return this;
     }
 
+    public setCustomNumbering(numberId: number, indentLevel: number): Paragraph {
+        this.properties.push(new NumberProperties(numberId, indentLevel));
+        return this;
+    }
+
     public style(styleId: string): Paragraph {
         this.properties.push(new Style(styleId));
         return this;


### PR DESCRIPTION
This PR solves the various issues with Numbering. 
Numbering file must be in order:
 - first all the abstract numbering
 - then all the concrete numbering
Example:
```
<w:numbering ...>
  <w:abstractNum id="0" ...>
  <w:abstractNum id="1" ...>
  .... any number of abstractNum and then the concrete numbering
 <w:num w:numId="3">
     <w:abstractNumId w:val="0" />
 </w:num>
</w:numbering>
```

Note: If not in this format, then only Microsoft Word - will mix up the numbering and it will not work correctly.

 