### PR TITLE
paragraph: add support for page break before format property

### DIFF
--- a/src/file/paragraph/formatting/page-break.spec.ts
+++ b/src/file/paragraph/formatting/page-break.spec.ts
@@ -1,7 +1,7 @@
 import { assert } from "chai";
 
 import { Utility } from "../../../tests/utility";
-import { PageBreak } from "./page-break";
+import { PageBreak, PageBreakBefore } from "./page-break";
 
 describe("PageBreak", () => {
     let pageBreak: PageBreak;
@@ -28,5 +28,13 @@ describe("PageBreak", () => {
             const newJson = Utility.jsonify(pageBreak);
             assert.equal(newJson.root[1].rootKey, "w:br");
         });
+    });
+});
+
+describe("PageBreakBefore", () => {
+    it("should create page break before", () => {
+        const pageBreakBefore = new PageBreakBefore();
+        const newJson = Utility.jsonify(pageBreakBefore);
+        assert.equal(newJson.rootKey, "w:pageBreakBefore");
     });
 });

--- a/src/file/paragraph/formatting/page-break.ts
+++ b/src/file/paragraph/formatting/page-break.ts
@@ -19,3 +19,12 @@ export class PageBreak extends Run {
         this.root.push(new Break());
     }
 }
+
+/**
+ * Add page break before the paragraph if there is no one added before.
+ */
+export class PageBreakBefore extends XmlComponent {
+    constructor() {
+        super("w:pageBreakBefore");
+    }
+}

--- a/src/file/paragraph/paragraph.spec.ts
+++ b/src/file/paragraph/paragraph.spec.ts
@@ -161,6 +161,22 @@ describe("Paragraph", () => {
         });
     });
 
+    describe("#pageBreakBefore()", () => {
+        it("should add page break before to JSON", () => {
+            paragraph.pageBreakBefore();
+            const tree = new Formatter().format(paragraph);
+            expect(tree).to.deep.equal({
+                "w:p": [
+                    {
+                        "w:pPr": [{
+                            "w:pageBreakBefore": []
+                        }],
+                    }
+                ],
+            });
+        });
+    });
+
     describe("#bullet()", () => {
         it("should add list paragraph style to JSON", () => {
             paragraph.bullet();

--- a/src/file/paragraph/paragraph.ts
+++ b/src/file/paragraph/paragraph.ts
@@ -8,7 +8,7 @@ import { Alignment } from "./formatting/alignment";
 import { ThematicBreak } from "./formatting/border";
 import { Indent } from "./formatting/indent";
 import { KeepLines, KeepNext } from "./formatting/keep";
-import { PageBreak } from "./formatting/page-break";
+import { PageBreak, PageBreakBefore } from "./formatting/page-break";
 import { ISpacingProperties, Spacing } from "./formatting/spacing";
 import { Style } from "./formatting/style";
 import { CenterTabStop, LeftTabStop, MaxRightTabStop, RightTabStop } from "./formatting/tab-stop";
@@ -101,6 +101,11 @@ export class Paragraph extends XmlComponent {
 
     public pageBreak(): Paragraph {
         this.root.push(new PageBreak());
+        return this;
+    }
+
+    public pageBreakBefore(): Paragraph {
+        this.properties.push(new PageBreakBefore());
         return this;
     }
 


### PR DESCRIPTION
This PR adds support for adding format property Page Break Before. If set, then the paragraph will start on a new page. 
It's different then adding a manual page break (as new element), because in the case when there is already added page break before the paragraph-> this will not add a page break.