### PR TITLE
feature: add multiple sections to the document inc. headers and footers

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "awesome-typescript-loader": "^3.4.1",
     "chai": "^3.5.0",
     "glob": "^7.1.2",
+    "jszip": "^3.1.5",
     "mocha": "^3.2.0",
     "mocha-webpack": "^1.0.1",
     "prettier": "^1.10.2",

--- a/src/export/packer/compiler.spec.ts
+++ b/src/export/packer/compiler.spec.ts
@@ -1,0 +1,76 @@
+/* tslint:disable:typedef space-before-function-paren */
+import * as fs from "fs";
+
+import { Compiler } from "./compiler";
+import { File } from "../../file";
+import { expect } from "chai";
+
+import * as JSZip from "jszip";
+
+describe("Compiler", () => {
+    let compiler: Compiler;
+    let file: File;
+
+    beforeEach(() => {
+        file = new File();
+        compiler = new Compiler(file);
+    });
+
+    describe("#compile()", () => {
+        it("should pack all the content", async function() {
+            this.timeout(99999999);
+            const fileName = "build/tests/test.docx";
+            await compiler.compile(fs.createWriteStream(fileName));
+
+            const docxFile = fs.readFileSync(fileName);
+            const zipFile: JSZip = await JSZip.loadAsync(docxFile);
+            const fileNames = Object.keys(zipFile.files).map((f) => zipFile.files[f].name);
+
+            expect(fileNames).is.an.instanceof(Array);
+            expect(fileNames).has.length(12);
+            expect(fileNames).to.include("word/document.xml");
+            expect(fileNames).to.include("word/styles.xml");
+            expect(fileNames).to.include("docProps/core.xml");
+            expect(fileNames).to.include("docProps/app.xml");
+            expect(fileNames).to.include("word/numbering.xml");
+            expect(fileNames).to.include("word/header1.xml");
+            expect(fileNames).to.include("word/_rels/header1.xml.rels");
+            expect(fileNames).to.include("word/footer1.xml");
+            expect(fileNames).to.include("word/_rels/footer1.xml.rels");
+            expect(fileNames).to.include("word/_rels/document.xml.rels");
+            expect(fileNames).to.include("[Content_Types].xml");
+            expect(fileNames).to.include("_rels/.rels");
+        });
+
+        it("should pack all additional headers and footers", async function() {
+            file.createFooter();
+            file.createFooter();
+            file.createHeader();
+            file.createHeader();
+
+            this.timeout(99999999);
+            const fileName = "build/tests/test2.docx";
+            await compiler.compile(fs.createWriteStream(fileName));
+
+            const docxFile = fs.readFileSync(fileName);
+            const zipFile: JSZip = await JSZip.loadAsync(docxFile);
+            const fileNames = Object.keys(zipFile.files).map((f) => zipFile.files[f].name);
+
+            expect(fileNames).is.an.instanceof(Array);
+            expect(fileNames).has.length(20);
+
+            expect(fileNames).to.include("word/header1.xml");
+            expect(fileNames).to.include("word/_rels/header1.xml.rels");
+            expect(fileNames).to.include("word/header2.xml");
+            expect(fileNames).to.include("word/_rels/header2.xml.rels");
+            expect(fileNames).to.include("word/header3.xml");
+            expect(fileNames).to.include("word/_rels/header3.xml.rels");
+            expect(fileNames).to.include("word/footer1.xml");
+            expect(fileNames).to.include("word/_rels/footer1.xml.rels");
+            expect(fileNames).to.include("word/footer2.xml");
+            expect(fileNames).to.include("word/_rels/footer2.xml.rels");
+            expect(fileNames).to.include("word/footer3.xml");
+            expect(fileNames).to.include("word/_rels/footer3.xml.rels");
+        });
+    });
+});

--- a/src/export/packer/compiler.ts
+++ b/src/export/packer/compiler.ts
@@ -33,10 +33,6 @@ export class Compiler {
         const xmlNumbering = xml(this.formatter.format(this.file.Numbering));
         const xmlRelationships = xml(this.formatter.format(this.file.DocumentRelationships));
         const xmlFileRelationships = xml(this.formatter.format(this.file.FileRelationships));
-        const xmlHeader = xml(this.formatter.format(this.file.Header.Header));
-        const xmlFooter = xml(this.formatter.format(this.file.Footer.Footer));
-        const xmlHeaderRelationships = xml(this.formatter.format(this.file.Header.Relationships));
-        const xmlFooterRelationships = xml(this.formatter.format(this.file.Footer.Relationships));
         const xmlContentTypes = xml(this.formatter.format(this.file.ContentTypes));
         const xmlAppProperties = xml(this.formatter.format(this.file.AppProperties));
 
@@ -60,24 +56,32 @@ export class Compiler {
             name: "word/numbering.xml",
         });
 
-        this.archive.append(xmlHeader, {
-            name: "word/header1.xml",
-        });
+        // headers
+        for (let i = 0; i < this.file.Headers.length; i++) {
+            const element = this.file.Headers[i];
+            this.archive.append(xml(this.formatter.format(element.Header)), {
+                name: `word/header${i + 1}.xml`,
+            });
 
-        this.archive.append(xmlFooter, {
-            name: "word/footer1.xml",
-        });
+            this.archive.append(xml(this.formatter.format(element.Relationships)), {
+                name: `word/_rels/header${i + 1}.xml.rels`,
+            });
+        }
+
+        // footers
+        for (let i = 0; i < this.file.Footers.length; i++) {
+            const element = this.file.Footers[i];
+            this.archive.append(xml(this.formatter.format(element.Footer)), {
+                name: `word/footer${i + 1}.xml`,
+            });
+
+            this.archive.append(xml(this.formatter.format(element.Relationships)), {
+                name: `word/_rels/footer${i + 1}.xml.rels`,
+            });
+        }
 
         this.archive.append(xmlRelationships, {
             name: "word/_rels/document.xml.rels",
-        });
-
-        this.archive.append(xmlHeaderRelationships, {
-            name: "word/_rels/header1.xml.rels",
-        });
-
-        this.archive.append(xmlFooterRelationships, {
-            name: "word/_rels/footer1.xml.rels",
         });
 
         this.archive.append(xmlContentTypes, {

--- a/src/file/content-types/content-types.spec.ts
+++ b/src/file/content-types/content-types.spec.ts
@@ -1,0 +1,139 @@
+import { expect } from "chai";
+import { Formatter } from "../../export/formatter";
+import { ContentTypes } from "./content-types";
+describe("ContentTypes", () => {
+    let contentTypes: ContentTypes;
+
+    beforeEach(() => {
+        contentTypes = new ContentTypes();
+    });
+
+    describe("#constructor()", () => {
+        it("should create default content types", () => {
+            const tree = new Formatter().format(contentTypes);
+
+            expect(tree["Types"]).to.be.an.instanceof(Array);
+
+            expect(tree["Types"][0]).to.deep.equal({ _attr: { xmlns: "http://schemas.openxmlformats.org/package/2006/content-types" } });
+            expect(tree["Types"][1]).to.deep.equal({ Default: [{ _attr: { ContentType: "image/png", Extension: "png" } }] });
+            expect(tree["Types"][2]).to.deep.equal({ Default: [{ _attr: { ContentType: "image/jpeg", Extension: "jpeg" } }] });
+            expect(tree["Types"][3]).to.deep.equal({ Default: [{ _attr: { ContentType: "image/jpeg", Extension: "jpg" } }] });
+            expect(tree["Types"][4]).to.deep.equal({ Default: [{ _attr: { ContentType: "image/bmp", Extension: "bmp" } }] });
+            expect(tree["Types"][5]).to.deep.equal({ Default: [{ _attr: { ContentType: "image/gif", Extension: "gif" } }] });
+            expect(tree["Types"][6]).to.deep.equal({
+                Default: [{ _attr: { ContentType: "application/vnd.openxmlformats-package.relationships+xml", Extension: "rels" } }],
+            });
+            expect(tree["Types"][7]).to.deep.equal({ Default: [{ _attr: { ContentType: "application/xml", Extension: "xml" } }] });
+            expect(tree["Types"][8]).to.deep.equal({
+                Override: [
+                    {
+                        _attr: {
+                            ContentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml",
+                            PartName: "/word/document.xml",
+                        },
+                    },
+                ],
+            });
+            expect(tree["Types"][9]).to.deep.equal({
+                Override: [
+                    {
+                        _attr: {
+                            ContentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml",
+                            PartName: "/word/styles.xml",
+                        },
+                    },
+                ],
+            });
+            expect(tree["Types"][10]).to.deep.equal({
+                Override: [
+                    {
+                        _attr: {
+                            ContentType: "application/vnd.openxmlformats-package.core-properties+xml",
+                            PartName: "/docProps/core.xml",
+                        },
+                    },
+                ],
+            });
+            expect(tree["Types"][11]).to.deep.equal({
+                Override: [
+                    {
+                        _attr: {
+                            ContentType: "application/vnd.openxmlformats-officedocument.extended-properties+xml",
+                            PartName: "/docProps/app.xml",
+                        },
+                    },
+                ],
+            });
+            expect(tree["Types"][12]).to.deep.equal({
+                Override: [
+                    {
+                        _attr: {
+                            ContentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml",
+                            PartName: "/word/numbering.xml",
+                        },
+                    },
+                ],
+            });
+        });
+    });
+
+    describe("#addFooter()", () => {
+        it("should add footer", () => {
+            contentTypes.addFooter(101);
+            contentTypes.addFooter(102);
+            const tree = new Formatter().format(contentTypes);
+
+            expect(tree["Types"][13]).to.deep.equal({
+                Override: [
+                    {
+                        _attr: {
+                            ContentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml",
+                            PartName: "/word/footer101.xml",
+                        },
+                    },
+                ],
+            });
+
+            expect(tree["Types"][14]).to.deep.equal({
+                Override: [
+                    {
+                        _attr: {
+                            ContentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml",
+                            PartName: "/word/footer102.xml",
+                        },
+                    },
+                ],
+            });
+        });
+    });
+
+    describe("#addHeader()", () => {
+        it("should add header", () => {
+            contentTypes.addHeader(201);
+            contentTypes.addHeader(202);
+            const tree = new Formatter().format(contentTypes);
+
+            expect(tree["Types"][13]).to.deep.equal({
+                Override: [
+                    {
+                        _attr: {
+                            ContentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml",
+                            PartName: "/word/header201.xml",
+                        },
+                    },
+                ],
+            });
+
+            expect(tree["Types"][14]).to.deep.equal({
+                Override: [
+                    {
+                        _attr: {
+                            ContentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml",
+                            PartName: "/word/header202.xml",
+                        },
+                    },
+                ],
+            });
+        });
+    });
+});

--- a/src/file/content-types/content-types.ts
+++ b/src/file/content-types/content-types.ts
@@ -24,11 +24,21 @@ export class ContentTypes extends XmlComponent {
         this.root.push(
             new Override("application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml", "/word/document.xml"),
         );
-        this.root.push(new Override("application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml", "/word/header1.xml"));
-        this.root.push(new Override("application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml", "/word/footer1.xml"));
         this.root.push(new Override("application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml", "/word/styles.xml"));
         this.root.push(new Override("application/vnd.openxmlformats-package.core-properties+xml", "/docProps/core.xml"));
         this.root.push(new Override("application/vnd.openxmlformats-officedocument.extended-properties+xml", "/docProps/app.xml"));
         this.root.push(new Override("application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml", "/word/numbering.xml"));
+    }
+
+    addFooter(index: number) {
+        this.root.push(
+            new Override("application/vnd.openxmlformats-officedocument.wordprocessingml.footer+xml", `/word/footer${index}.xml`),
+        );
+    }
+
+    addHeader(index: number) {
+        this.root.push(
+            new Override("application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml", `/word/header${index}.xml`),
+        );
     }
 }

--- a/src/file/document/body/body.spec.ts
+++ b/src/file/document/body/body.spec.ts
@@ -1,39 +1,42 @@
-// import { assert } from "chai";
+import { expect } from "chai";
 
-// import { Utility } from "../../../tests/utility";
-// import { Body } from "./";
+import { Formatter } from "../../../export/formatter";
+import { Body } from "./body";
 
 describe("Body", () => {
-    // let body: Body;
+    let body: Body;
 
     beforeEach(() => {
-        // body = new Body();
+        body = new Body();
     });
 
-    // describe("#constructor()", () => {
-    //     it("should create the Section Properties", () => {
-    //         const newJson = Utility.jsonify(body);
-    //         assert.equal(newJson.root[0].rootKey, "w:sectPr");
-    //     });
+    describe("#constructor()", () => {
+        it("should create default section", () => {
+            const formatted = new Formatter().format(body)["w:body"][0];
+            expect(formatted)
+                .to.have.property("w:sectPr")
+                .and.to.be.an.instanceof(Array);
+            expect(formatted["w:sectPr"]).to.have.length(7);
+        });
+    });
 
-    //     it("should create the Page Size", () => {
-    //         const newJson = Utility.jsonify(body);
-    //         assert.equal(newJson.root[1].rootKey, "w:pgSz");
-    //     });
+    describe("addSection", () => {
+        it("should add section with options", () => {
+            body.addSection({
+                width: 10000,
+                height: 10000,
+            });
 
-    //     it("should create the Page Margin", () => {
-    //         const newJson = Utility.jsonify(body);
-    //         assert.equal(newJson.root[2].rootKey, "w:pgMar");
-    //     });
+            const formatted = new Formatter().format(body)["w:body"];
+            expect(formatted).to.be.an.instanceof(Array);
+            const defaultSectionPr = formatted[0]["w:p"][1]["w:pPr"][0]["w:sectPr"];
 
-    //     it("should create the Columns", () => {
-    //         const newJson = Utility.jsonify(body);
-    //         assert.equal(newJson.root[3].rootKey, "w:cols");
-    //     });
+            // check that this is the default section and added first in paragraph
+            expect(defaultSectionPr[0]).to.deep.equal({ "w:pgSz": [{ _attr: { "w:h": 16838, "w:w": 11906, "w:orient": "portrait" } }] });
 
-    //     it("should create the Document Grid", () => {
-    //         const newJson = Utility.jsonify(body);
-    //         assert.equal(newJson.root[4].rootKey, "w:docGrid");
-    //     });
-    // });
+            // check for new section (since it's the last one, it's direct child of body)
+            const newSection = formatted[1]["w:sectPr"];
+            expect(newSection[0]).to.deep.equal({ "w:pgSz": [{ _attr: { "w:h": 10000, "w:w": 10000, "w:orient": "portrait" } }] });
+        });
+    });
 });

--- a/src/file/document/body/body.ts
+++ b/src/file/document/body/body.ts
@@ -1,14 +1,59 @@
-import { XmlComponent } from "file/xml-components";
+import { XmlComponent, IXmlableObject } from "file/xml-components";
 import { SectionProperties, SectionPropertiesOptions } from "./section-properties/section-properties";
+import { Paragraph, ParagraphProperties } from "../..";
 
 export class Body extends XmlComponent {
+    private defaultSection: SectionProperties;
+
+    private sections: SectionProperties[] = [];
+
     constructor(sectionPropertiesOptions?: SectionPropertiesOptions) {
         super("w:body");
 
-        this.root.push(new SectionProperties(sectionPropertiesOptions));
+        this.defaultSection = new SectionProperties(sectionPropertiesOptions);
+        this.sections.push(this.defaultSection);
+    }
+
+    /**
+     * Adds new section properties.
+     * Note: Previous section is created in paragraph after the current element, and then new section will be added.
+     * The spec says:
+     *  - section element should be in the last paragraph of the section
+     *  - last section should be direct child of body
+     * @param section new section
+     */
+    addSection(section: SectionPropertiesOptions | SectionProperties) {
+        const currentSection = this.sections.pop() as SectionProperties;
+        this.root.push(this.createSectionParagraph(currentSection));
+        if (section instanceof SectionProperties) {
+            this.sections.push(section);
+        } else {
+            this.sections.push(new SectionProperties(section));
+        }
+    }
+    public prepForXml(): IXmlableObject {
+        if (this.sections.length === 1) {
+            this.root.push(this.sections[0]);
+        } else if (this.sections.length > 1) {
+            throw new Error("Invalid usage of sections. At the end of the body element there must be ONE section.");
+        }
+
+        return super.prepForXml();
     }
 
     public push(component: XmlComponent): void {
         this.root.push(component);
+    }
+
+    get DefaultSection() {
+        return this.defaultSection;
+    }
+
+    private createSectionParagraph(section: SectionProperties) {
+        const paragraph = new Paragraph();
+        const properties = new ParagraphProperties();
+        properties.addChildElement(section);
+        paragraph.addChildElement(properties);
+        return paragraph;
     }
 }

--- a/src/file/document/body/index.ts
+++ b/src/file/document/body/index.ts
@@ -1,1 +1,2 @@
 export * from "./body";
+export * from "./section-properties";

--- a/src/file/document/body/section-properties/footer-reference/footer-reference-attributes.ts
+++ b/src/file/document/body/section-properties/footer-reference/footer-reference-attributes.ts
@@ -1,5 +1,11 @@
 import { XmlAttributeComponent } from "file/xml-components";
 
+export enum FooterReferenceType {
+    DEFAULT = "default",
+    FIRST = "first",
+    EVEN = "even",
+}
+
 export interface IFooterReferenceAttributes {
     type: string;
     id: string;

--- a/src/file/document/body/section-properties/footer-reference/footer-reference.ts
+++ b/src/file/document/body/section-properties/footer-reference/footer-reference.ts
@@ -1,13 +1,19 @@
 import { XmlComponent } from "file/xml-components";
-import { FooterReferenceAttributes } from "./footer-reference-attributes";
+import { FooterReferenceAttributes, FooterReferenceType } from "./footer-reference-attributes";
+
+export interface FooterOptions {
+    footerType?: FooterReferenceType;
+    footerId?: number;
+}
 
 export class FooterReference extends XmlComponent {
-    constructor() {
+    constructor(options: FooterOptions) {
         super("w:footerReference");
+
         this.root.push(
             new FooterReferenceAttributes({
-                type: "default",
-                id: `rId${4}`,
+                type: options.footerType || FooterReferenceType.DEFAULT,
+                id: `rId${options.footerId}`,
             }),
         );
     }

--- a/src/file/document/body/section-properties/footer-reference/index.ts
+++ b/src/file/document/body/section-properties/footer-reference/index.ts
@@ -1,0 +1,2 @@
+export * from "./footer-reference";
+export * from "./footer-reference-attributes";

--- a/src/file/document/body/section-properties/header-reference/header-reference-attributes.ts
+++ b/src/file/document/body/section-properties/header-reference/header-reference-attributes.ts
@@ -1,5 +1,11 @@
 import { XmlAttributeComponent } from "file/xml-components";
 
+export enum HeaderReferenceType {
+    DEFAULT = "default",
+    FIRST = "first",
+    EVEN = "even",
+}
+
 export interface IHeaderReferenceAttributes {
     type: string;
     id: string;

--- a/src/file/document/body/section-properties/header-reference/header-reference.ts
+++ b/src/file/document/body/section-properties/header-reference/header-reference.ts
@@ -1,13 +1,18 @@
 import { XmlComponent } from "file/xml-components";
-import { HeaderReferenceAttributes } from "./header-reference-attributes";
+import { HeaderReferenceAttributes, HeaderReferenceType } from "./header-reference-attributes";
+
+export interface HeaderOptions {
+    headerType?: HeaderReferenceType;
+    headerId?: number;
+}
 
 export class HeaderReference extends XmlComponent {
-    constructor() {
+    constructor(options: HeaderOptions) {
         super("w:headerReference");
         this.root.push(
             new HeaderReferenceAttributes({
-                type: "default",
-                id: `rId${3}`,
+                type: options.headerType || HeaderReferenceType.DEFAULT,
+                id: `rId${options.headerId}`,
             }),
         );
     }

--- a/src/file/document/body/section-properties/header-reference/index.ts
+++ b/src/file/document/body/section-properties/header-reference/index.ts
@@ -1,0 +1,2 @@
+export * from "./header-reference";
+export * from "./header-reference-attributes";

--- a/src/file/document/body/section-properties/index.ts
+++ b/src/file/document/body/section-properties/index.ts
@@ -1,0 +1,5 @@
+export * from "./section-properties";
+export * from "./footer-reference";
+export * from "./header-reference";
+export * from "./page-size";
+export * from "./page-number";

--- a/src/file/document/body/section-properties/page-number/index.ts
+++ b/src/file/document/body/section-properties/page-number/index.ts
@@ -1,0 +1,1 @@
+export * from "./page-number";

--- a/src/file/document/body/section-properties/page-number/page-number.ts
+++ b/src/file/document/body/section-properties/page-number/page-number.ts
@@ -1,0 +1,41 @@
+// http://officeopenxml.com/WPSectionPgNumType.php
+import { XmlComponent, XmlAttributeComponent } from "file/xml-components";
+
+export enum PageNumberFormat {
+    CARDINAL_TEXT = "cardinalText",
+    DECIMAL = "decimal",
+    DECIMAL_ENCLOSED_CIRCLE = "decimalEnclosedCircle",
+    DECIMAL_ENCLOSED_FULL_STOP = "decimalEnclosedFullstop",
+    DECIMAL_ENCLOSED_PAREN = "decimalEnclosedParen",
+    DECIMAL_ZERO = "decimalZero",
+    LOWER_LETTER = "lowerLetter",
+    LOWER_ROMAN = "lowerRoman",
+    NONE = "none",
+    ORDINAL_TEXT = "ordinalText",
+    UPPER_LETTER = "upperLetter",
+    UPPER_ROMAN = "upperRoman",
+}
+
+export interface IPageNumberTypeAttributes {
+    pageNumberStart?: number;
+    pageNumberFormatType?: PageNumberFormat;
+}
+
+export class PageNumberTypeAttributes extends XmlAttributeComponent<IPageNumberTypeAttributes> {
+    protected xmlKeys = {
+        pageNumberStart: "w:start",
+        pageNumberFormatType: "w:fmt",
+    };
+}
+
+export class PageNumberType extends XmlComponent {
+    constructor(start?: number, numberFormat?: PageNumberFormat) {
+        super("w:pgNumType");
+        this.root.push(
+            new PageNumberTypeAttributes({
+                pageNumberStart: start,
+                pageNumberFormatType: numberFormat,
+            }),
+        );
+    }
+}

--- a/src/file/document/body/section-properties/page-size/index.ts
+++ b/src/file/document/body/section-properties/page-size/index.ts
@@ -1,0 +1,2 @@
+export * from "./page-size";
+export * from "./page-size-attributes";

--- a/src/file/document/body/section-properties/page-size/page-size-attributes.ts
+++ b/src/file/document/body/section-properties/page-size/page-size-attributes.ts
@@ -1,9 +1,14 @@
 import { XmlAttributeComponent } from "file/xml-components";
 
+export enum PageOrientation {
+    PORTRAIT = "portrait",
+    LANDSCAPE = "landscape",
+}
+
 export interface IPageSizeAttributes {
     width?: number;
     height?: number;
-    orientation?: string;
+    orientation?: PageOrientation;
 }
 
 export class PageSizeAttributes extends XmlAttributeComponent<IPageSizeAttributes> {

--- a/src/file/document/body/section-properties/page-size/page-size.spec.ts
+++ b/src/file/document/body/section-properties/page-size/page-size.spec.ts
@@ -2,11 +2,12 @@ import { expect } from "chai";
 
 import { Formatter } from "../../../../../export/formatter";
 import { PageSize } from "./page-size";
+import { PageOrientation } from "./page-size-attributes";
 
 describe("PageSize", () => {
     describe("#constructor()", () => {
         it("should create page size with portrait", () => {
-            const properties = new PageSize(100, 200, "portrait");
+            const properties = new PageSize(100, 200, PageOrientation.PORTRAIT);
             const tree = new Formatter().format(properties);
 
             expect(Object.keys(tree)).to.deep.equal(["w:pgSz"]);
@@ -15,7 +16,7 @@ describe("PageSize", () => {
         });
 
         it("should create page size with horizontal and invert the lengths", () => {
-            const properties = new PageSize(100, 200, "landscape");
+            const properties = new PageSize(100, 200, PageOrientation.LANDSCAPE);
             const tree = new Formatter().format(properties);
 
             expect(Object.keys(tree)).to.deep.equal(["w:pgSz"]);

--- a/src/file/document/body/section-properties/page-size/page-size.ts
+++ b/src/file/document/body/section-properties/page-size/page-size.ts
@@ -1,11 +1,11 @@
 import { XmlComponent } from "file/xml-components";
-import { PageSizeAttributes } from "./page-size-attributes";
+import { PageSizeAttributes, PageOrientation } from "./page-size-attributes";
 
 export class PageSize extends XmlComponent {
-    constructor(width: number, height: number, orientation: string) {
+    constructor(width: number, height: number, orientation: PageOrientation) {
         super("w:pgSz");
 
-        const flip = orientation === "landscape";
+        const flip = orientation === PageOrientation.LANDSCAPE;
 
         this.root.push(
             new PageSizeAttributes({

--- a/src/file/document/body/section-properties/section-properties.spec.ts
+++ b/src/file/document/body/section-properties/section-properties.spec.ts
@@ -2,6 +2,7 @@ import { expect } from "chai";
 
 import { Formatter } from "../../../../export/formatter";
 import { SectionProperties } from "./section-properties";
+import { FooterReferenceType, PageNumberFormat } from ".";
 
 describe("SectionProperties", () => {
     describe("#constructor()", () => {
@@ -18,6 +19,11 @@ describe("SectionProperties", () => {
                 gutter: 0,
                 space: 708,
                 linePitch: 360,
+                headerId: 100,
+                footerId: 200,
+                footerType: FooterReferenceType.EVEN,
+                pageNumberStart: 10,
+                pageNumberFormatType: PageNumberFormat.CARDINAL_TEXT,
             });
             const tree = new Formatter().format(properties);
             expect(Object.keys(tree)).to.deep.equal(["w:sectPr"]);
@@ -38,6 +44,12 @@ describe("SectionProperties", () => {
                     },
                 ],
             });
+
+            expect(tree["w:sectPr"][2]).to.deep.equal({ "w:cols": [{ _attr: { "w:space": 708 } }] });
+            expect(tree["w:sectPr"][3]).to.deep.equal({ "w:docGrid": [{ _attr: { "w:linePitch": 360 } }] });
+            expect(tree["w:sectPr"][4]).to.deep.equal({ "w:headerReference": [{ _attr: { "r:id": "rId100", "w:type": "default" } }] });
+            expect(tree["w:sectPr"][5]).to.deep.equal({ "w:footerReference": [{ _attr: { "r:id": "rId200", "w:type": "even" } }] });
+            expect(tree["w:sectPr"][6]).to.deep.equal({ "w:pgNumType": [{ _attr: { "w:fmt": "cardinalText", "w:start": 10 } }] });
         });
 
         it("should create section properties with no options", () => {
@@ -61,6 +73,11 @@ describe("SectionProperties", () => {
                     },
                 ],
             });
+            expect(tree["w:sectPr"][2]).to.deep.equal({ "w:cols": [{ _attr: { "w:space": 708 } }] });
+            expect(tree["w:sectPr"][3]).to.deep.equal({ "w:docGrid": [{ _attr: { "w:linePitch": 360 } }] });
+            expect(tree["w:sectPr"][4]).to.deep.equal({ "w:headerReference": [{ _attr: { "r:id": "rId0", "w:type": "default" } }] });
+            expect(tree["w:sectPr"][5]).to.deep.equal({ "w:footerReference": [{ _attr: { "r:id": "rId0", "w:type": "default" } }] });
+            expect(tree["w:sectPr"][6]).to.deep.equal({ "w:pgNumType": [{ _attr: { "w:fmt": "decimal" } }] });
         });
 
         it("should create section properties with changed options", () => {

--- a/src/file/document/body/section-properties/section-properties.ts
+++ b/src/file/document/body/section-properties/section-properties.ts
@@ -4,16 +4,25 @@ import { Columns } from "./columns/columns";
 import { IColumnsAttributes } from "./columns/columns-attributes";
 import { DocumentGrid } from "./doc-grid/doc-grid";
 import { IDocGridAttributesProperties } from "./doc-grid/doc-grid-attributes";
-import { FooterReference } from "./footer-reference/footer-reference";
-import { HeaderReference } from "./header-reference/header-reference";
+import { FooterReference, FooterOptions } from "./footer-reference/footer-reference";
+import { HeaderReference, HeaderOptions } from "./header-reference/header-reference";
 import { PageMargin } from "./page-margin/page-margin";
 import { IPageMarginAttributes } from "./page-margin/page-margin-attributes";
 import { PageSize } from "./page-size/page-size";
-import { IPageSizeAttributes } from "./page-size/page-size-attributes";
+import { IPageSizeAttributes, PageOrientation } from "./page-size/page-size-attributes";
+import { FooterReferenceType, IPageNumberTypeAttributes, PageNumberType, PageNumberFormat } from ".";
+import { HeaderReferenceType } from "./header-reference/header-reference-attributes";
 
-export type SectionPropertiesOptions = IPageSizeAttributes & IPageMarginAttributes & IColumnsAttributes & IDocGridAttributesProperties;
+export type SectionPropertiesOptions = IPageSizeAttributes &
+    IPageMarginAttributes &
+    IColumnsAttributes &
+    IDocGridAttributesProperties &
+    HeaderOptions &
+    FooterOptions &
+    IPageNumberTypeAttributes;
 
 export class SectionProperties extends XmlComponent {
+    private options: SectionPropertiesOptions;
     constructor(options?: SectionPropertiesOptions) {
         super("w:sectPr");
 
@@ -29,7 +38,13 @@ export class SectionProperties extends XmlComponent {
             gutter: 0,
             space: 708,
             linePitch: 360,
-            orientation: "portrait",
+            orientation: PageOrientation.PORTRAIT,
+            headerType: HeaderReferenceType.DEFAULT,
+            headerId: 0,
+            footerType: FooterReferenceType.DEFAULT,
+            footerId: 0,
+            pageNumberStart: undefined,
+            pageNumberFormatType: PageNumberFormat.DECIMAL,
         };
 
         const mergedOptions = {
@@ -51,7 +66,25 @@ export class SectionProperties extends XmlComponent {
         );
         this.root.push(new Columns(mergedOptions.space));
         this.root.push(new DocumentGrid(mergedOptions.linePitch));
-        this.root.push(new HeaderReference());
-        this.root.push(new FooterReference());
+        this.root.push(
+            new HeaderReference({
+                headerType: mergedOptions.headerType,
+                headerId: mergedOptions.headerId,
+            }),
+        );
+        this.root.push(
+            new FooterReference({
+                footerType: mergedOptions.footerType,
+                footerId: mergedOptions.footerId,
+            }),
+        );
+
+        this.root.push(new PageNumberType(mergedOptions.pageNumberStart, mergedOptions.pageNumberFormatType));
+
+        this.options = mergedOptions;
+    }
+
+    get Options() {
+        return this.options;
     }
 }

--- a/src/file/document/document.spec.ts
+++ b/src/file/document/document.spec.ts
@@ -23,6 +23,11 @@ describe("Document", () => {
             }
             assert.isTrue(true);
         });
+
+        it("should create default section", () => {
+            const body = new Formatter().format(document)["w:document"][1]["w:body"];
+            expect(body[0]).to.have.property("w:sectPr");
+        });
     });
 
     describe("#createParagraph", () => {
@@ -33,7 +38,7 @@ describe("Document", () => {
             expect(body)
                 .to.be.an("array")
                 .which.has.length.at.least(1);
-            expect(body[1]).to.have.property("w:p");
+            expect(body[0]).to.have.property("w:p");
         });
 
         it("should use the text given to create a run in the paragraph", () => {
@@ -43,7 +48,7 @@ describe("Document", () => {
             expect(body)
                 .to.be.an("array")
                 .which.has.length.at.least(1);
-            expect(body[1])
+            expect(body[0])
                 .to.have.property("w:p")
                 .which.includes({
                     "w:r": [{ "w:rPr": [] }, { "w:t": [{ _attr: { "xml:space": "preserve" } }, "sample paragraph text"] }],
@@ -59,7 +64,7 @@ describe("Document", () => {
             expect(body)
                 .to.be.an("array")
                 .which.has.length.at.least(1);
-            expect(body[1]).to.have.property("w:tbl");
+            expect(body[0]).to.have.property("w:tbl");
         });
 
         it("should create a table with the correct dimensions", () => {
@@ -68,7 +73,7 @@ describe("Document", () => {
             expect(body)
                 .to.be.an("array")
                 .which.has.length.at.least(1);
-            expect(body[1])
+            expect(body[0])
                 .to.have.property("w:tbl")
                 .which.includes({
                     "w:tblGrid": [
@@ -77,7 +82,7 @@ describe("Document", () => {
                         { "w:gridCol": [{ _attr: { "w:w": 1 } }] },
                     ],
                 });
-            expect(body[1]["w:tbl"].filter((x) => x["w:tr"])).to.have.length(2);
+            expect(body[0]["w:tbl"].filter((x) => x["w:tr"])).to.have.length(2);
         });
     });
 });

--- a/src/file/document/document.ts
+++ b/src/file/document/document.ts
@@ -70,4 +70,8 @@ export class Document extends XmlComponent {
 
         return;
     }
+
+    get Body() {
+        return this.body;
+    }
 }

--- a/src/file/document/index.ts
+++ b/src/file/document/index.ts
@@ -1,1 +1,2 @@
 export * from "./document";
+export * from "./body";

--- a/src/file/footer-wrapper.ts
+++ b/src/file/footer-wrapper.ts
@@ -9,8 +9,8 @@ export class FooterWrapper {
     private readonly footer: Footer;
     private readonly relationships: Relationships;
 
-    constructor(private readonly media: Media) {
-        this.footer = new Footer();
+    constructor(private readonly media: Media, referenceId: number) {
+        this.footer = new Footer(referenceId);
         this.relationships = new Relationships();
     }
 

--- a/src/file/footer/footer.ts
+++ b/src/file/footer/footer.ts
@@ -6,8 +6,10 @@ import { Table } from "../table";
 import { FooterAttributes } from "./footer-attributes";
 
 export class Footer extends XmlComponent {
-    constructor() {
+    private refId: number;
+    constructor(referenceNumber: number) {
         super("w:ftr");
+        this.refId = referenceNumber;
         this.root.push(
             new FooterAttributes({
                 wpc: "http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas",
@@ -28,6 +30,10 @@ export class Footer extends XmlComponent {
                 wps: "http://schemas.microsoft.com/office/word/2010/wordprocessingShape",
             }),
         );
+    }
+
+    get referenceId() {
+        return this.refId;
     }
 
     public addParagraph(paragraph: Paragraph): void {

--- a/src/file/header-wrapper.ts
+++ b/src/file/header-wrapper.ts
@@ -9,8 +9,8 @@ export class HeaderWrapper {
     private readonly header: Header;
     private readonly relationships: Relationships;
 
-    constructor(private readonly media: Media) {
-        this.header = new Header();
+    constructor(private readonly media: Media, referenceId: number) {
+        this.header = new Header(referenceId);
         this.relationships = new Relationships();
     }
 

--- a/src/file/header/header.ts
+++ b/src/file/header/header.ts
@@ -6,8 +6,10 @@ import { Table } from "../table";
 import { HeaderAttributes } from "./header-attributes";
 
 export class Header extends XmlComponent {
-    constructor() {
+    private refId: number;
+    constructor(referenceNumber: number) {
         super("w:hdr");
+        this.refId = referenceNumber;
         this.root.push(
             new HeaderAttributes({
                 wpc: "http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas",
@@ -28,6 +30,10 @@ export class Header extends XmlComponent {
                 wps: "http://schemas.microsoft.com/office/word/2010/wordprocessingShape",
             }),
         );
+    }
+
+    get referenceId() {
+        return this.refId;
     }
 
     public addParagraph(paragraph: Paragraph): void {

--- a/src/file/index.ts
+++ b/src/file/index.ts
@@ -4,5 +4,6 @@ export * from "./file";
 export * from "./numbering";
 export * from "./media";
 export * from "./drawing";
+export * from "./document";
 export * from "./styles";
 export * from "./xml-components";

--- a/src/file/media/media.ts
+++ b/src/file/media/media.ts
@@ -11,9 +11,9 @@ export class Media {
         this.map = new Map<string, IMediaData>();
     }
 
-    private createMedia(key: string, relationshipsCount, dimensions, data: fs.ReadStream | Buffer, filePath?: string) {
+    private createMedia(key: string, referenceId, dimensions, data: fs.ReadStream | Buffer, filePath?: string) {
         const imageData = {
-            referenceId: this.map.size + relationshipsCount + 1,
+            referenceId: referenceId,
             stream: data,
             path: filePath,
             fileName: key,
@@ -42,13 +42,13 @@ export class Media {
         return data;
     }
 
-    public addMedia(filePath: string, relationshipsCount: number): IMediaData {
+    public addMedia(filePath: string, referenceId: number): IMediaData {
         const key = path.basename(filePath);
         const dimensions = sizeOf(filePath);
-        return this.createMedia(key, relationshipsCount, dimensions, fs.createReadStream(filePath), filePath);
+        return this.createMedia(key, referenceId, dimensions, fs.createReadStream(filePath), filePath);
     }
 
-    public addMediaWithData(fileName: string, data: Buffer, relationshipsCount: number, width?, height?): IMediaData {
+    public addMediaWithData(fileName: string, data: Buffer, referenceId: number, width?, height?): IMediaData {
         const key = fileName;
         let dimensions;
         if (width && height) {
@@ -60,7 +60,7 @@ export class Media {
             dimensions = sizeOf(data);
         }
 
-        return this.createMedia(key, relationshipsCount, dimensions, data);
+        return this.createMedia(key, referenceId, dimensions, data);
     }
 
     public get array(): IMediaData[] {


### PR DESCRIPTION
This PR adds support for creating and having multiple sections in the document.
Besides the sections, now there is option to add multiple headers and footers (so sections can have different headers and footers).
Also all the supported section properties are implemented according to: `http://officeopenxml.com/WPsection.php`

Example of the new methods:

```ts
    const header = this.document.createHeader();
    const footer = this.document.createFooter();
    const defaultSectionOptions = this.document.Document.Body.DefaultSection.Options;
    this.document.addSection({
      ...defaultSectionOptions,
      headerId: header.Header.referenceId,
      footerId: footer.Footer.referenceId,
      pageNumberStart: 1,
      pageNumberFormatType: PageNumberFormat.DECIMAL,
    });
```

First (initial section) is created and it's stored in `Body.DefaultSection` for later usage.