### PR TITLE
bug: Not all content from external styles was imported correctly

### DIFF
--- a/src/file/styles/external-styles-factory.spec.ts
+++ b/src/file/styles/external-styles-factory.spec.ts
@@ -10,6 +10,17 @@ describe("External styles factory", () => {
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <w:styles xmlns:mc="first" xmlns:r="second">
             <w:docDefaults>
+            <w:rPrDefault>
+                <w:rPr>
+                    <w:rFonts w:ascii="Arial" w:eastAsiaTheme="minorHAnsi" w:hAnsi="Arial" w:cstheme="minorHAnsi"/>
+                    <w:lang w:val="en-US" w:eastAsia="en-US" w:bidi="ar-SA"/>
+                </w:rPr>
+            </w:rPrDefault>
+            <w:pPrDefault>
+                <w:pPr>
+                    <w:spacing w:after="160" w:line="259" w:lineRule="auto"/>
+                </w:pPr>
+            </w:pPrDefault>
             </w:docDefaults>
             
             <w:latentStyles w:defLockedState="1" w:defUIPriority="99">
@@ -52,7 +63,63 @@ describe("External styles factory", () => {
             expect(importedStyle.root.length).to.equal(5);
             expect(importedStyle.root[1]).to.eql({
                 deleted: false,
-                root: [],
+                root: [
+                    {
+                        deleted: false,
+                        root: [
+                            {
+                                deleted: false,
+                                root: [
+                                    {
+                                        _attr: {
+                                            "w:ascii": "Arial",
+                                            "w:cstheme": "minorHAnsi",
+                                            "w:eastAsiaTheme": "minorHAnsi",
+                                            "w:hAnsi": "Arial",
+                                        },
+                                        deleted: false,
+                                        root: [],
+                                        rootKey: "w:rFonts",
+                                    },
+                                    {
+                                        _attr: {
+                                            "w:bidi": "ar-SA",
+                                            "w:eastAsia": "en-US",
+                                            "w:val": "en-US",
+                                        },
+                                        deleted: false,
+                                        root: [],
+                                        rootKey: "w:lang",
+                                    },
+                                ],
+                                rootKey: "w:rPr",
+                            },
+                        ],
+                        rootKey: "w:rPrDefault",
+                    },
+                    {
+                        deleted: false,
+                        root: [
+                            {
+                                deleted: false,
+                                root: [
+                                    {
+                                        _attr: {
+                                            "w:after": "160",
+                                            "w:line": "259",
+                                            "w:lineRule": "auto",
+                                        },
+                                        deleted: false,
+                                        root: [],
+                                        rootKey: "w:spacing",
+                                    },
+                                ],
+                                rootKey: "w:pPr",
+                            },
+                        ],
+                        rootKey: "w:pPrDefault",
+                    },
+                ],
                 rootKey: "w:docDefaults",
             });
             expect(importedStyle.root[2]).to.eql({

--- a/src/file/styles/external-styles-factory.ts
+++ b/src/file/styles/external-styles-factory.ts
@@ -1,6 +1,6 @@
 import { Styles } from "./";
 import * as fastXmlParser from "fast-xml-parser";
-import { ImportedXmlComponent, ImportedRootElementAttributes, parseOptions, convertToXmlComponent } from "./../../file/xml-components";
+import { ImportedRootElementAttributes, parseOptions, convertToXmlComponent } from "./../../file/xml-components";
 
 export class ExternalStylesFactory {
     /**
@@ -34,7 +34,12 @@ export class ExternalStylesFactory {
         Object.keys(xmlStyles)
             .filter((element) => element !== "_attr" && element !== "w:style")
             .forEach((element) => {
-                importedStyle.push(new ImportedXmlComponent(element, xmlStyles[element]._attr));
+                const converted = convertToXmlComponent(element, xmlStyles[element]);
+                if (Array.isArray(converted)) {
+                    converted.forEach((c) => importedStyle.push(c));
+                } else {
+                    importedStyle.push(converted);
+                }
             });
 
         // convert the styles one by one


### PR DESCRIPTION
This PR fixes the bug when using external styles. Because of that document defaults and latent styles were not applied from the imported styles.

## Technical details
When styles were imported, they are converted to an XmlComponent of type Styles. But conversion was wrong from all elements expect `w:style`. They need to be converted to an XmlComponent.