### PR TITLE
Add support to define suffix on a numbering level

### DIFF
--- a/src/file/numbering/index.ts
+++ b/src/file/numbering/index.ts
@@ -1,2 +1,3 @@
 export * from "./numbering";
 export * from "./abstract-numbering";
+export * from "./level";

--- a/src/file/numbering/level.ts
+++ b/src/file/numbering/level.ts
@@ -60,6 +60,23 @@ class LevelJc extends XmlComponent {
     }
 }
 
+export enum LevelSuffix {
+    NOTHING = "nothing",
+    SPACE = "space",
+    TAB = "tab",
+}
+
+class Suffix extends XmlComponent {
+    constructor(value: LevelSuffix) {
+        super("w:suff");
+        this.root.push(
+            new Attributes({
+                val: value,
+            }),
+        );
+    }
+}
+
 export class LevelBase extends XmlComponent {
     private readonly paragraphProperties: ParagraphProperties;
     private readonly runProperties: RunProperties;
@@ -91,6 +108,11 @@ export class LevelBase extends XmlComponent {
 
         this.root.push(this.paragraphProperties);
         this.root.push(this.runProperties);
+    }
+
+    public setSuffix(value: LevelSuffix) {
+        this.root.push(new Suffix(value));
+        return this;
     }
 
     public addParagraphProperty(property: XmlComponent): Level {


### PR DESCRIPTION
This PR adds support to define suffix for numbering level. Suffix is the character between the number and the text. If omitted (not defined for a level), word will use TAB.

```ts
export enum LevelSuffix {
    NOTHING = "nothing",
    SPACE = "space",
    TAB = "tab",
}
```

```ts
const docxNumbering = document.Numbering;
const numbering = docxNumbering.createAbstractNumbering();

numbering
  .createLevel(0, 'decimal', '%1', 'left')
  .setSuffix(LevelSuffix.SPACE);

```